### PR TITLE
Fix landing detection tolerance

### DIFF
--- a/src/sim/Collision.ts
+++ b/src/sim/Collision.ts
@@ -54,7 +54,7 @@ export function testLanding(player: Player, platform: Platform): boolean {
   const top = platform.position.y + platform.height;
   const feet = player.getFeetY();
   const prevFeet = player.getPreviousFeetY();
-  const wasAbove = prevFeet - CFG.player.footOffset >= top;
+  const wasAbove = prevFeet >= top;
   const isBelow = feet <= top;
   if (!wasAbove || !isBelow) {
     return false;


### PR DESCRIPTION
## Summary
- relax landing detection by requiring the player's previous feet position to simply be above the platform top, preventing missed collisions that caused sticking

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d4f7704af8832db8195702b332bb51