### PR TITLE
Add lobby character selection support

### DIFF
--- a/NETWORK_PROTOCOL.md
+++ b/NETWORK_PROTOCOL.md
@@ -252,6 +252,7 @@ Frequency: 20–30 Hz; server accepts `tick` in window `[currentTick - maxRollba
 ```json
 {"type":"ready_set","pv":1,"seq":9,"ts":1737765,"payload":{"ready":true}}
 {"type":"start_request","pv":1,"seq":10,"ts":1737765,"payload":{"countdownSec":3}}
+{"type":"character_select","pv":1,"seq":11,"ts":1737765,"payload":{"characterId":"violet"}}
 ```
 
 ---
@@ -271,7 +272,7 @@ Frequency: 20–30 Hz; server accepts `tick` in window `[currentTick - maxRollba
     "role":"master",
     "roomState":"lobby",
     "lobby":{
-      "players":[{"id":"p_abcd","name":"bene","ready":true,"role":"master"}],
+      "players":[{"id":"p_abcd","name":"bene","ready":true,"role":"master","characterId":"aurora"}],
       "maxPlayers":4
     },
     "cfg":{ "tps":60,"snapshotRateHz":10,"maxRollbackTicks":120,"inputLeadTicks":2,
@@ -292,8 +293,8 @@ Frequency: 20–30 Hz; server accepts `tick` in window `[currentTick - maxRollba
   "payload":{
     "roomState":"lobby",
     "players":[
-      {"id":"p_abcd","name":"bene","ready":true,"role":"master"},
-      {"id":"p_efgh","name":"ally","ready":false,"role":"member"}
+      {"id":"p_abcd","name":"bene","ready":true,"role":"master","characterId":"aurora"},
+      {"id":"p_efgh","name":"ally","ready":false,"role":"member","characterId":"cobalt"}
     ]
   }
 }
@@ -522,6 +523,7 @@ Frequency: 20–30 Hz; server accepts `tick` in window `[currentTick - maxRollba
 
   * Added **Room Master + Lobby** flow (REST `/start`, optional WS `start_request`).
   * New S2C: `lobby_state`, `start_countdown`, `role_changed`; `welcome` extended with `role`, `roomState`, `lobby`.
+  * New C2S: `character_select`; lobby players now advertise optional `characterId`.
   * Added errors: `NOT_MASTER`, `ROOM_STATE_INVALID`, `ROOM_NOT_READY`, `START_ALREADY`, `COUNTDOWN_ACTIVE`.
   * Clarified local `ws://`/`http://` allowances; compression “recommended” vs “required”.
 
@@ -557,11 +559,18 @@ interface C2S_Input { tick: number; axisX: number; jump?: boolean; shoot?: boole
 interface C2S_InputBatch { startTick: number; frames: Array<{ d: number; axisX: number; jump?: boolean; shoot?: boolean }>; }
 interface C2S_Ping { t0: number; }
 interface C2S_Reconnect { playerId: string; resumeToken: string; lastAckTick: number; }
+interface C2S_CharacterSelect { characterId: string; }
 interface C2S_ReadySet { ready: boolean; }               // optional
 interface C2S_StartRequest { countdownSec?: number; }    // optional
 
 // ----- Server → Client -----
-interface LobbyPlayer { id: string; name: string; ready: boolean; role: "master" | "member"; }
+interface LobbyPlayer {
+  id: string;
+  name: string;
+  ready: boolean;
+  role: "master" | "member";
+  characterId?: string;
+}
 
 interface NetWorldCfg {
   worldWidth: number; platformWidth: number; platformHeight: number;
@@ -582,7 +591,11 @@ interface S2C_Welcome {
   lobby?: { players: LobbyPlayer[]; maxPlayers: number; };
   cfg: NetConfig; featureFlags?: Record<string, boolean>;
 }
-interface S2C_LobbyState { roomState: "lobby" | "starting" | "running" | "finished"; players: LobbyPlayer[]; }
+interface S2C_LobbyState {
+  roomState: "lobby" | "starting" | "running" | "finished";
+  players: LobbyPlayer[];
+  maxPlayers?: number;
+}
 interface S2C_StartCountdown { startAtMs: number; serverTick: number; countdownSec: number; }
 interface S2C_Start { startTick: number; serverTick: number; serverTimeMs: number; tps: number; }
 

--- a/src/config/characters.ts
+++ b/src/config/characters.ts
@@ -16,13 +16,55 @@ export interface CharacterOption {
 }
 
 export const CHARACTER_OPTIONS: readonly CharacterOption[] = [
-  { id: 'aurora', name: 'Aurora', tint: 0xff8a80, accent: '#ff8a80', accentSecondary: '#ff5252' },
-  { id: 'cobalt', name: 'Cobalt', tint: 0x82b1ff, accent: '#82b1ff', accentSecondary: '#448aff' },
-  { id: 'jade', name: 'Jade', tint: 0x69f0ae, accent: '#69f0ae', accentSecondary: '#00e676' },
-  { id: 'sunrise', name: 'Sunrise', tint: 0xffd740, accent: '#ffd740', accentSecondary: '#ffab00' },
-  { id: 'violet', name: 'Violet', tint: 0xb388ff, accent: '#b388ff', accentSecondary: '#7c4dff' },
-  { id: 'ember', name: 'Ember', tint: 0xff7043, accent: '#ff7043', accentSecondary: '#ff3d00' },
-  { id: 'ghost', name: 'Ghost', tint: 0xcfd8dc, accent: '#cfd8dc', accentSecondary: '#90a4ae' },
+  {
+    id: 'aurora',
+    name: 'Aurora',
+    tint: 0xff8a80,
+    accent: '#ff8a80',
+    accentSecondary: '#ff5252',
+  },
+  {
+    id: 'cobalt',
+    name: 'Cobalt',
+    tint: 0x82b1ff,
+    accent: '#82b1ff',
+    accentSecondary: '#448aff',
+  },
+  {
+    id: 'jade',
+    name: 'Jade',
+    tint: 0x69f0ae,
+    accent: '#69f0ae',
+    accentSecondary: '#00e676',
+  },
+  {
+    id: 'sunrise',
+    name: 'Sunrise',
+    tint: 0xffd740,
+    accent: '#ffd740',
+    accentSecondary: '#ffab00',
+  },
+  {
+    id: 'violet',
+    name: 'Violet',
+    tint: 0xb388ff,
+    accent: '#b388ff',
+    accentSecondary: '#7c4dff',
+  },
+  {
+    id: 'ember',
+    name: 'Ember',
+    tint: 0xff7043,
+    accent: '#ff7043',
+    accentSecondary: '#ff3d00',
+  },
+  {
+    id: 'ghost',
+    name: 'Ghost',
+    tint: 0xcfd8dc,
+    accent: '#cfd8dc',
+    accentSecondary: '#90a4ae',
+  },
 ] as const;
 
 export const DEFAULT_CHARACTER_ID: CharacterId = CHARACTER_OPTIONS[0]!.id;
@@ -31,7 +73,9 @@ export const CHARACTER_OPTION_MAP = new Map<CharacterId, CharacterOption>(
   CHARACTER_OPTIONS.map((option) => [option.id, option])
 );
 
-export function getCharacterOption(id: CharacterId | undefined): CharacterOption {
+export function getCharacterOption(
+  id: CharacterId | undefined
+): CharacterOption {
   if (!id) {
     return CHARACTER_OPTIONS[0]!;
   }

--- a/src/net/NetClient.ts
+++ b/src/net/NetClient.ts
@@ -3,6 +3,7 @@ import {
   C2SJoin,
   C2SReadySet,
   C2SStartRequest,
+  C2SCharacterSelect,
   ClientEnvelope,
   Envelope,
   NetInputPayload,
@@ -24,6 +25,7 @@ import {
 import { parseServerEnvelope } from './guards';
 import { useNetStore } from '../state/store';
 import type { NetMetricsState } from '../state/store';
+import type { CharacterId } from '../config/characters';
 
 export interface NetClientOptions {
   url?: string;
@@ -271,6 +273,25 @@ export class NetClient {
       payload.countdownSec = Math.floor(countdownSec);
     }
     this.sendEnvelope('start_request', payload);
+  }
+
+  selectCharacter(characterId: CharacterId): void {
+    if (!this.enabled) {
+      return;
+    }
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      if (this.opts.debug) {
+        console.warn(
+          '[NetClient] Cannot send character_select; socket not open'
+        );
+      }
+      return;
+    }
+    if (this.roomState !== 'lobby') {
+      return;
+    }
+    const payload: C2SCharacterSelect = { characterId };
+    this.sendEnvelope('character_select', payload);
   }
 
   destroy(): void {

--- a/src/net/Protocol.ts
+++ b/src/net/Protocol.ts
@@ -1,4 +1,5 @@
 import type { PlayerInput } from '../core/Types';
+import type { CharacterId } from '../config/characters';
 
 export type Pv = 1;
 export const PROTOCOL_PV: Pv = 1;
@@ -10,7 +11,8 @@ export type ClientMessageType =
   | 'ping'
   | 'reconnect'
   | 'ready_set'
-  | 'start_request';
+  | 'start_request'
+  | 'character_select';
 
 export type ServerMessageType =
   | 'welcome'
@@ -71,6 +73,7 @@ export interface LobbyPlayer {
   name: string;
   ready: boolean;
   role: PlayerRole;
+  characterId?: CharacterId;
 }
 
 export interface LobbySnapshot {
@@ -123,6 +126,10 @@ export interface C2SReadySet {
 
 export interface C2SStartRequest {
   countdownSec?: number;
+}
+
+export interface C2SCharacterSelect {
+  characterId: CharacterId;
 }
 
 // Server → Client
@@ -215,7 +222,8 @@ export type ClientEnvelope =
   | Envelope<C2SPing, 'ping'>
   | Envelope<C2SReconnect, 'reconnect'>
   | Envelope<C2SReadySet, 'ready_set'>
-  | Envelope<C2SStartRequest, 'start_request'>;
+  | Envelope<C2SStartRequest, 'start_request'>
+  | Envelope<C2SCharacterSelect, 'character_select'>;
 
 export type ServerEnvelope =
   | Envelope<S2CWelcome, 'welcome'>

--- a/src/net/config.ts
+++ b/src/net/config.ts
@@ -75,7 +75,8 @@ const pickString = (
 };
 
 const parseProtocolPv = (): Pv => {
-  const value = readString('VITE_PROTOCOL_PV') ?? readString('VITE_NET_PROTOCOL_PV');
+  const value =
+    readString('VITE_PROTOCOL_PV') ?? readString('VITE_NET_PROTOCOL_PV');
   const parsed = Number(value);
   return parsed === 1 ? 1 : 1;
 };
@@ -83,7 +84,8 @@ const parseProtocolPv = (): Pv => {
 const defaultPlayerName = 'web-player';
 const defaultClientVersion = 'web-dev';
 
-const fallbackWsUrl = env.MODE === 'development' ? 'ws://localhost:8081/v1/ws' : undefined;
+const fallbackWsUrl =
+  env.MODE === 'development' ? 'ws://localhost:8081/v1/ws' : undefined;
 const fallbackApiBase =
   env.MODE === 'development' ? 'http://localhost:8080' : undefined;
 
@@ -97,25 +99,51 @@ const apiBaseUrl = pickString(
   readString('VITE_NET_API_BASE_URL'),
   fallbackApiBase
 );
-const wsToken = pickString(readString('VITE_WS_TOKEN'), readString('VITE_NET_WS_TOKEN'));
+const wsToken = pickString(
+  readString('VITE_WS_TOKEN'),
+  readString('VITE_NET_WS_TOKEN')
+);
 
 export const NET_CFG: NetRuntimeConfig = {
   enabled: Boolean(wsUrl || apiBaseUrl),
   apiBaseUrl,
   wsUrl,
   wsToken,
-  playerName: readString('VITE_PLAYER_NAME') ?? readString('VITE_NET_PLAYER_NAME') ?? defaultPlayerName,
+  playerName:
+    readString('VITE_PLAYER_NAME') ??
+    readString('VITE_NET_PLAYER_NAME') ??
+    defaultPlayerName,
   clientVersion:
-    readString('VITE_CLIENT_VERSION') ?? readString('VITE_NET_CLIENT_VERSION') ?? defaultClientVersion,
+    readString('VITE_CLIENT_VERSION') ??
+    readString('VITE_NET_CLIENT_VERSION') ??
+    defaultClientVersion,
   device: readString('VITE_DEVICE') ?? readString('VITE_NET_DEVICE'),
   capabilities: {
-    tilt: toBool(readString('VITE_CAP_TILT') ?? readString('VITE_NET_CAP_TILT'), false),
-    vibrate: toBool(readString('VITE_CAP_VIBRATE') ?? readString('VITE_NET_CAP_VIBRATE'), true),
+    tilt: toBool(
+      readString('VITE_CAP_TILT') ?? readString('VITE_NET_CAP_TILT'),
+      false
+    ),
+    vibrate: toBool(
+      readString('VITE_CAP_VIBRATE') ?? readString('VITE_NET_CAP_VIBRATE'),
+      true
+    ),
   },
-  flushIntervalMs: Math.max(16, toNumber(readString('VITE_FLUSH_MS') ?? readString('VITE_NET_FLUSH_MS'), 50)),
-  pingIntervalMs: Math.max(1000, toNumber(readString('VITE_PING_MS') ?? readString('VITE_NET_PING_MS'), 5000)),
+  flushIntervalMs: Math.max(
+    16,
+    toNumber(readString('VITE_FLUSH_MS') ?? readString('VITE_NET_FLUSH_MS'), 50)
+  ),
+  pingIntervalMs: Math.max(
+    1000,
+    toNumber(readString('VITE_PING_MS') ?? readString('VITE_NET_PING_MS'), 5000)
+  ),
   debug: toBool(readString('VITE_NET_DEBUG'), env.MODE === 'development'),
-  maxPlayers: Math.max(1, toNumber(readString('VITE_MAX_PLAYERS') ?? readString('VITE_NET_MAX_PLAYERS'), 4)),
+  maxPlayers: Math.max(
+    1,
+    toNumber(
+      readString('VITE_MAX_PLAYERS') ?? readString('VITE_NET_MAX_PLAYERS'),
+      4
+    )
+  ),
   defaultRegion: readString('VITE_REGION') ?? readString('VITE_NET_REGION'),
   defaultMode: readString('VITE_MODE') ?? readString('VITE_NET_MODE'),
   protocolPv: parseProtocolPv(),

--- a/src/render/GameScene.ts
+++ b/src/render/GameScene.ts
@@ -116,6 +116,22 @@ export class GameScene extends Phaser.Scene {
     this.scene.start(SceneKeys.Menu);
   };
 
+  private readonly handleCharacterSelect = (characterId: CharacterId): void => {
+    if (!this.netClient?.enabled) {
+      return;
+    }
+    const state = useNetStore.getState();
+    const playerId = state.playerId;
+    if (!playerId) {
+      return;
+    }
+    const changed = state.setCharacterSelection(playerId, characterId);
+    if (!changed) {
+      return;
+    }
+    this.netClient.selectCharacter(characterId);
+  };
+
   constructor() {
     super(SceneKeys.Game);
   }
@@ -410,7 +426,9 @@ export class GameScene extends Phaser.Scene {
       `#${value.toString(16).padStart(6, '0')}`;
     if (this.playerSprite && this.playerLabel) {
       const localOption = getCharacterOption(
-        this.localPlayerId ? this.characterSelections[this.localPlayerId] : undefined
+        this.localPlayerId
+          ? this.characterSelections[this.localPlayerId]
+          : undefined
       );
       this.playerSprite.setTint(localOption.tint);
       this.playerLabel.setColor(toHex(localOption.tint));
@@ -428,7 +446,7 @@ export class GameScene extends Phaser.Scene {
   private refreshPlayerLabels(): void {
     if (this.playerLabel) {
       const name = this.localPlayerId
-        ? this.playerNames.get(this.localPlayerId) ?? 'You'
+        ? (this.playerNames.get(this.localPlayerId) ?? 'You')
         : 'You';
       this.playerLabel.setText(name);
     }
@@ -450,6 +468,7 @@ export class GameScene extends Phaser.Scene {
       onReadyToggle: this.handleReadyToggle,
       onStartMatch: this.handleStartMatch,
       onLeaveRoom: this.handleLeaveLobby,
+      onSelectCharacter: this.handleCharacterSelect,
     });
     this.lobbyVisible = true;
   }
@@ -476,7 +495,7 @@ export class GameScene extends Phaser.Scene {
     this.handleNetLatency(this.netLatencyMs);
   }
 
-  private handleNetStart(start: S2CStart): void {
+  private handleNetStart(_start: S2CStart): void {
     if (!this.netClient.enabled) {
       return;
     }
@@ -485,7 +504,7 @@ export class GameScene extends Phaser.Scene {
     this.clock.resume();
   }
 
-  private handleNetStartCountdown(countdown: S2CStartCountdown): void {
+  private handleNetStartCountdown(_countdown: S2CStartCountdown): void {
     if (!this.netClient.enabled) {
       return;
     }

--- a/src/tests/net/guards.spec.ts
+++ b/src/tests/net/guards.spec.ts
@@ -49,8 +49,20 @@ describe('parseServerEnvelope', () => {
         roomState: 'lobby' as const,
         lobby: {
           players: [
-            { id: 'p_master', name: 'Master', ready: true, role: 'master' as const },
-            { id: 'p_member', name: 'Member', ready: false, role: 'member' as const },
+            {
+              id: 'p_master',
+              name: 'Master',
+              ready: true,
+              role: 'master' as const,
+              characterId: 'aurora',
+            },
+            {
+              id: 'p_member',
+              name: 'Member',
+              ready: false,
+              role: 'member' as const,
+              characterId: 'cobalt',
+            },
           ],
           maxPlayers: 4,
         },
@@ -71,7 +83,12 @@ describe('parseServerEnvelope', () => {
       payload: {
         roomState: 'lobby' as const,
         players: [
-          { id: 'p_master', name: 'Master', ready: true, role: 'master' as const },
+          {
+            id: 'p_master',
+            name: 'Master',
+            ready: true,
+            role: 'master' as const,
+          },
           // Missing ready flag
           { id: 'p_member', name: 'Member', role: 'member' as const },
         ],
@@ -81,6 +98,29 @@ describe('parseServerEnvelope', () => {
     const result = parseServerEnvelope(invalid);
     expect(result.ok).toBe(false);
     expect(result.error).toContain('player.ready');
+  });
+
+  it('rejects lobby players with invalid character ids', () => {
+    const invalid = {
+      ...baseEnvelope,
+      type: 'lobby_state' as const,
+      payload: {
+        roomState: 'lobby' as const,
+        players: [
+          {
+            id: 'p_master',
+            name: 'Master',
+            ready: true,
+            role: 'master' as const,
+            characterId: 'not-real',
+          },
+        ],
+      },
+    } as unknown;
+
+    const result = parseServerEnvelope(invalid);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('characterId');
   });
 
   it('accepts start_countdown payloads', () => {

--- a/src/tests/state/store.spec.ts
+++ b/src/tests/state/store.spec.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { useNetStore } from '../../state/store';
+import type { CharacterId } from '../../config/characters';
+
+const asId = (value: CharacterId | undefined): CharacterId => value ?? 'aurora';
 
 const resetStore = () => {
   useNetStore.getState().reset();
@@ -19,8 +22,20 @@ describe('net store', () => {
     });
     store.setLobby(
       [
-        { id: 'p1', name: 'Master', ready: true, role: 'master' },
-        { id: 'p2', name: 'Ally', ready: false, role: 'member' },
+        {
+          id: 'p1',
+          name: 'Master',
+          ready: true,
+          role: 'master',
+          characterId: 'aurora',
+        },
+        {
+          id: 'p2',
+          name: 'Ally',
+          ready: false,
+          role: 'member',
+          characterId: 'cobalt',
+        },
       ],
       4
     );
@@ -30,6 +45,8 @@ describe('net store', () => {
     expect(next.roomId).toBe('room');
     expect(next.players).toHaveLength(2);
     expect(next.lobbyMaxPlayers).toBe(4);
+    expect(asId(next.characterSelections.p1)).toBe('aurora');
+    expect(asId(next.characterSelections.p2)).toBe('cobalt');
   });
 
   it('updates countdown and resets it', () => {
@@ -49,5 +66,53 @@ describe('net store', () => {
     expect(metrics.ackTick).toBe(10);
     expect(metrics.lastInputSeq).toBe(7);
     expect(metrics.skew).toBe(0);
+  });
+
+  it('tracks character selection changes', () => {
+    const store = useNetStore.getState();
+    store.setLobby(
+      [
+        {
+          id: 'p1',
+          name: 'Player',
+          ready: true,
+          role: 'master',
+          characterId: 'aurora',
+        },
+        {
+          id: 'p2',
+          name: 'Ally',
+          ready: false,
+          role: 'member',
+          characterId: 'cobalt',
+        },
+      ],
+      4
+    );
+    const changed = store.setCharacterSelection('p1', 'violet');
+    expect(changed).toBe(true);
+    const after = useNetStore.getState();
+    expect(after.characterSelections.p1).toBe('violet');
+    expect(after.players.find((p) => p.id === 'p1')?.characterId).toBe(
+      'violet'
+    );
+    const rejected = after.setCharacterSelection('p2', 'violet');
+    expect(rejected).toBe(false);
+    expect(useNetStore.getState().characterSelections.p2).toBe('cobalt');
+  });
+
+  it('reconciles missing character ids with defaults', () => {
+    const store = useNetStore.getState();
+    store.setLobby(
+      [
+        { id: 'p1', name: 'Master', ready: true, role: 'master' },
+        { id: 'p2', name: 'Member', ready: false, role: 'member' },
+      ],
+      4
+    );
+    const assigned = useNetStore.getState().characterSelections;
+    expect(Object.keys(assigned)).toContain('p1');
+    expect(Object.keys(assigned)).toContain('p2');
+    expect(assigned.p1).not.toBe(assigned.p2);
   });
 });

--- a/src/ui/Lobby.tsx
+++ b/src/ui/Lobby.tsx
@@ -12,6 +12,7 @@ interface LobbyProps {
   onToggleReady?: (ready: boolean) => void;
   onStart?: () => void;
   onLeave?: () => void;
+  onSelectCharacter?: (characterId: CharacterId) => void;
 }
 
 interface PlayerSummary {
@@ -165,9 +166,9 @@ const PlayerCard: React.FC<{ player: PlayerSummary }> = ({ player }) => {
         }}
       />
       <div style={{ display: 'flex', gap: '8px' }}>
-        <span style={readyBadgeStyle(player.ready)}>{
-          player.ready ? 'Ready' : 'Not Ready'
-        }</span>
+        <span style={readyBadgeStyle(player.ready)}>
+          {player.ready ? 'Ready' : 'Not Ready'}
+        </span>
         <span style={roleBadgeStyle(player.role)}>{player.role}</span>
       </div>
     </div>
@@ -178,6 +179,7 @@ export const Lobby: React.FC<LobbyProps> = ({
   onToggleReady,
   onStart,
   onLeave,
+  onSelectCharacter,
 }) => {
   const state = useNetStore(
     useCallback(
@@ -194,8 +196,6 @@ export const Lobby: React.FC<LobbyProps> = ({
       []
     )
   );
-
-  const selectCharacter = useNetStore((s) => s.setCharacterSelection);
 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -296,15 +296,15 @@ export const Lobby: React.FC<LobbyProps> = ({
 
   const handleCharacterSelect = useCallback(
     (characterId: CharacterId) => {
-      if (!state.playerId || !selectCharacter) {
+      if (!state.playerId || !onSelectCharacter) {
         return;
       }
       if (characterId === myCharacterId) {
         return;
       }
-      selectCharacter(state.playerId, characterId);
+      onSelectCharacter(characterId);
     },
-    [myCharacterId, selectCharacter, state.playerId]
+    [myCharacterId, onSelectCharacter, state.playerId]
   );
 
   return (
@@ -314,13 +314,25 @@ export const Lobby: React.FC<LobbyProps> = ({
           <div style={{ textAlign: 'left' }}>
             <h2 style={{ margin: 0, fontSize: '28px' }}>Waiting Room</h2>
             <div style={{ opacity: 0.75, fontSize: '14px' }}>
-              Room ID: <span style={{ fontFamily: 'monospace' }}>{state.roomId ?? '—'}</span>
+              Room ID:{' '}
+              <span style={{ fontFamily: 'monospace' }}>
+                {state.roomId ?? '—'}
+              </span>
             </div>
           </div>
-          <div style={{ textAlign: 'right', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+          <div
+            style={{
+              textAlign: 'right',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '6px',
+            }}
+          >
             <div style={{ fontSize: '14px', opacity: 0.75 }}>Role</div>
             <div style={{ fontWeight: 600 }}>{state.role.toUpperCase()}</div>
-            <span style={{ fontSize: '12px', opacity: 0.6 }}>Slots {roomCaption}</span>
+            <span style={{ fontSize: '12px', opacity: 0.6 }}>
+              Slots {roomCaption}
+            </span>
           </div>
         </div>
 
@@ -334,7 +346,13 @@ export const Lobby: React.FC<LobbyProps> = ({
           }}
         >
           <div style={stageStyle}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
               <div style={{ fontWeight: 600 }}>Players</div>
               <div style={{ fontSize: '12px', opacity: 0.6 }}>{statusText}</div>
             </div>
@@ -344,7 +362,9 @@ export const Lobby: React.FC<LobbyProps> = ({
               ))}
             </div>
             {players.length === 0 && (
-              <div style={{ fontSize: '14px', opacity: 0.6 }}>Waiting for players…</div>
+              <div style={{ fontSize: '14px', opacity: 0.6 }}>
+                Waiting for players…
+              </div>
             )}
           </div>
 
@@ -369,13 +389,16 @@ export const Lobby: React.FC<LobbyProps> = ({
               >
                 {CHARACTER_OPTIONS.map((option) => {
                   const active = option.id === myCharacterId;
-                  const takenByOther = charactersInUse.has(option.id) && !active;
+                  const takenByOther =
+                    charactersInUse.has(option.id) && !active;
                   return (
                     <button
                       key={option.id}
                       type="button"
                       onClick={() => handleCharacterSelect(option.id)}
-                      disabled={takenByOther || !state.playerId}
+                      disabled={
+                        takenByOther || !state.playerId || !onSelectCharacter
+                      }
                       style={characterOptionButton(
                         active,
                         takenByOther || !state.playerId,
@@ -460,7 +483,13 @@ export const Lobby: React.FC<LobbyProps> = ({
               }}
             >
               <div style={{ fontSize: '14px', opacity: 0.8 }}>{statusText}</div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '12px',
+                }}
+              >
                 {state.role === 'member' && onToggleReady && (
                   <button
                     type="button"

--- a/src/ui/UIManager.tsx
+++ b/src/ui/UIManager.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import { MainMenu } from './MainMenu';
 import { PauseOverlay } from './PauseOverlay';
 import { Lobby } from './Lobby';
+import type { CharacterId } from '../config/characters';
 
 type Screen = 'none' | 'menu' | 'lobby' | 'pause' | 'gameover';
 
@@ -22,6 +23,7 @@ interface Options extends MenuOptions {
   onReadyToggle?: (ready: boolean) => void;
   onStartMatch?: () => void;
   onLeaveRoom?: () => void;
+  onSelectCharacter?: (characterId: CharacterId) => void;
 }
 
 export class UIManager {
@@ -44,6 +46,7 @@ export class UIManager {
       onReadyToggle: undefined,
       onStartMatch: undefined,
       onLeaveRoom: undefined,
+      onSelectCharacter: undefined,
     };
     this.render();
   }
@@ -58,6 +61,7 @@ export class UIManager {
     onReadyToggle?: (ready: boolean) => void;
     onStartMatch?: () => void;
     onLeaveRoom?: () => void;
+    onSelectCharacter?: (characterId: CharacterId) => void;
   }) {
     this.screen = 'lobby';
     this.opts = { ...this.opts, ...options };
@@ -95,6 +99,7 @@ export class UIManager {
       onReadyToggle,
       onStartMatch,
       onLeaveRoom,
+      onSelectCharacter,
     } = this.opts;
     const screen = this.screen;
     this.root.render(
@@ -127,6 +132,7 @@ export class UIManager {
               onToggleReady={onReadyToggle}
               onStart={onStartMatch}
               onLeave={onLeaveRoom}
+              onSelectCharacter={onSelectCharacter}
             />
           )}
           {screen === 'pause' && <PauseOverlay onResume={onResume} />}


### PR DESCRIPTION
## Summary
- extend the documented wire protocol with a `character_select` client message and optional `characterId` fields on lobby snapshots
- wire the web client to send and reconcile character selections through the NetClient, store and UI so the lobby reflects shared choices
- tighten validation and tests around lobby payloads and update the lobby UI and e2e fixtures to use typed helpers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5499035b8832daa20297e1a485a26