### PR TITLE
Fix lobby selector caching to prevent infinite render loop

### DIFF
--- a/src/ui/Lobby.tsx
+++ b/src/ui/Lobby.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { shallow } from 'zustand/shallow';
 import playerSvgUrl from '../assets/images/player.svg';
 import {
   CHARACTER_OPTIONS,
@@ -194,7 +195,8 @@ export const Lobby: React.FC<LobbyProps> = ({
         characterSelections: s.characterSelections,
       }),
       []
-    )
+    ),
+    shallow
   );
 
   const [now, setNow] = useState(() => Date.now());


### PR DESCRIPTION
## Summary
- import Zustand's `shallow` comparator into the lobby UI component
- apply the comparator to the derived net store selector so the lobby snapshot stays stable between renders

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68d553aec344832d84330bc5e35d918e