### PR TITLE
Fix lobby store selection to prevent infinite re-render

### DIFF
--- a/src/ui/Lobby.tsx
+++ b/src/ui/Lobby.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/react/shallow';
 import playerSvgUrl from '../assets/images/player.svg';
 import {
   CHARACTER_OPTIONS,
@@ -183,20 +183,16 @@ export const Lobby: React.FC<LobbyProps> = ({
   onSelectCharacter,
 }) => {
   const state = useNetStore(
-    useCallback(
-      (s) => ({
-        playerId: s.playerId,
-        roomId: s.roomId,
-        role: s.role,
-        roomState: s.roomState,
-        players: s.players,
-        countdown: s.countdown,
-        lobbyMaxPlayers: s.lobbyMaxPlayers,
-        characterSelections: s.characterSelections,
-      }),
-      []
-    ),
-    shallow
+    useShallow((s) => ({
+      playerId: s.playerId,
+      roomId: s.roomId,
+      role: s.role,
+      roomState: s.roomState,
+      players: s.players,
+      countdown: s.countdown,
+      lobbyMaxPlayers: s.lobbyMaxPlayers,
+      characterSelections: s.characterSelections,
+    }))
   );
 
   const [now, setNow] = useState(() => Date.now());


### PR DESCRIPTION
## Summary
- swap Lobby component's zustand selector to use useShallow for memoized snapshots
- prevent repeated store updates from triggering React's infinite re-render guard during lobby display

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d555274c1c832d90716357894cc701