### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/net/NetClient.ts
+++ b/src/net/NetClient.ts
@@ -444,8 +444,11 @@ export class NetClient {
         break;
       default:
         if (this.opts.debug) {
-          console.warn('[NetClient] Unhandled message type', envelope.type);
+          const unhandled = envelope as ServerEnvelope;
+          console.warn('[NetClient] Unhandled message type', unhandled.type);
         }
+        const exhaustiveCheck: never = envelope;
+        void exhaustiveCheck;
     }
   }
 

--- a/src/render/GameScene.ts
+++ b/src/render/GameScene.ts
@@ -376,27 +376,32 @@ export class GameScene extends Phaser.Scene {
       this.clock.pause();
     }
     this.unsubscribeRoomState = useNetStore.subscribe(
-      (s) => s.roomState,
-      (roomState, previousRoomState) =>
-        this.onRoomStateChanged(roomState, previousRoomState)
+      (state, previousState) => {
+        if (state.roomState === previousState?.roomState) {
+          return;
+        }
+        this.onRoomStateChanged(state.roomState, previousState?.roomState);
+      }
     );
     this.unsubscribeCharacters = useNetStore.subscribe(
-      (s) => s.characterSelections,
-      (selections) => {
-        this.characterSelections = selections;
+      (state, previousState) => {
+        if (state.characterSelections === previousState?.characterSelections) {
+          return;
+        }
+        this.characterSelections = state.characterSelections;
         this.applyCharacterStyles();
       }
     );
-    this.unsubscribePlayers = useNetStore.subscribe(
-      (s) => s.players,
-      (players) => {
-        this.playerNames = new Map(
-          players.map((player) => [player.id, player.name])
-        );
-        this.applyCharacterStyles();
-        this.refreshPlayerLabels();
+    this.unsubscribePlayers = useNetStore.subscribe((state, previousState) => {
+      if (state.players === previousState?.players) {
+        return;
       }
-    );
+      this.playerNames = new Map(
+        state.players.map((player) => [player.id, player.name])
+      );
+      this.applyCharacterStyles();
+      this.refreshPlayerLabels();
+    });
   }
 
   private onRoomStateChanged(

--- a/src/tests/e2e/lobby.spec.ts
+++ b/src/tests/e2e/lobby.spec.ts
@@ -148,13 +148,21 @@ const resetSent = async (page: import('@playwright/test').Page) => {
   });
 };
 
+type MockSentMessage = {
+  type?: string;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
 const expectSentMessage = async (
   page: import('@playwright/test').Page,
-  predicate: (message: unknown) => boolean
+  predicate: (message: MockSentMessage) => boolean
 ) => {
-  await page.waitForFunction((fn: (message: unknown) => boolean) => {
+  await page.waitForFunction((fn: (message: MockSentMessage) => boolean) => {
     const sent = (window as MockSocketWindow).__mockSent;
-    return Array.isArray(sent) && sent.some((msg) => fn(msg));
+    return (
+      Array.isArray(sent) && sent.some((msg) => fn(msg as MockSentMessage))
+    );
   }, predicate);
 };
 

--- a/src/tests/net/guards.spec.ts
+++ b/src/tests/net/guards.spec.ts
@@ -73,7 +73,10 @@ describe('parseServerEnvelope', () => {
 
     const result = parseServerEnvelope(welcome);
     expect(result.ok).toBe(true);
-    expect(result.value?.payload.playerId).toBe('p_master');
+    if (!result.value || result.value.type !== 'welcome') {
+      throw new Error('Expected welcome envelope');
+    }
+    expect(result.value.payload.playerId).toBe('p_master');
   });
 
   it('rejects lobby_state messages with malformed players', () => {
@@ -136,7 +139,10 @@ describe('parseServerEnvelope', () => {
 
     const result = parseServerEnvelope(countdown);
     expect(result.ok).toBe(true);
-    expect(result.value?.payload.countdownSec).toBe(3);
+    if (!result.value || result.value.type !== 'start_countdown') {
+      throw new Error('Expected start_countdown envelope');
+    }
+    expect(result.value.payload.countdownSec).toBe(3);
   });
 
   it('rejects invalid snapshot payloads', () => {


### PR DESCRIPTION
## Summary
- ensure the NetClient handles unknown server messages exhaustively while keeping debug logging safe
- adjust GameScene store subscriptions to use the current Zustand listener signature
- tighten e2e and unit test helpers to satisfy stricter TypeScript checks

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d55a55ef4c832db1989075489e9c72