### PR TITLE
Document playerId requirement and update client leave flow

### DIFF
--- a/NETWORK_PROTOCOL.md
+++ b/NETWORK_PROTOCOL.md
@@ -130,8 +130,18 @@ POST /v1/rooms/{roomId}/join
 
 ```http
 POST /v1/rooms/{roomId}/leave
+{ "playerId": "p01", "reason": "left voluntarily" }  // reason optional
 → 204
 ```
+
+*Request body*
+
+| Field | Type   | Required | Notes |
+|-------|--------|----------|-------|
+| `playerId` | `string` | ✅ | Must match the authenticated player for the supplied `wsToken`. |
+| `reason` | `string` | ❌ | Optional free-form context (e.g., `"left voluntarily"`, `"disconnected"`). |
+
+Clients must always include the `playerId`. The server validates it against the room membership that was bound when the `wsToken` was issued. Omitting or mismatching the `playerId` results in `422 Unprocessable Entity` with an error such as `missing field "playerId"`.
 
 ### 5.4 Status
 

--- a/src/net/NetClient.ts
+++ b/src/net/NetClient.ts
@@ -442,13 +442,15 @@ export class NetClient {
           }
         });
         break;
-      default:
+      default: {
         if (this.opts.debug) {
           const unhandled = envelope as ServerEnvelope;
           console.warn('[NetClient] Unhandled message type', unhandled.type);
         }
         const exhaustiveCheck: never = envelope;
         void exhaustiveCheck;
+        break;
+      }
     }
   }
 

--- a/src/net/matchmaking.ts
+++ b/src/net/matchmaking.ts
@@ -42,6 +42,7 @@ interface RequestOptions {
 }
 
 interface LeaveRoomOptions extends RequestOptions {
+  playerId: string;
   reason?: string;
 }
 
@@ -137,11 +138,16 @@ export const joinRoom = async (
 
 export const leaveRoom = async (
   roomId: string,
-  options?: LeaveRoomOptions
+  options: LeaveRoomOptions
 ): Promise<void> => {
-  const payload = options?.reason ? { reason: options.reason } : {};
+  const payload: { playerId: string; reason?: string } = {
+    playerId: options.playerId,
+  };
+  if (options.reason) {
+    payload.reason = options.reason;
+  }
   const response = await fetch(
-    buildUrl(`/v1/rooms/${encodeURIComponent(roomId)}/leave`, options?.baseUrl),
+    buildUrl(`/v1/rooms/${encodeURIComponent(roomId)}/leave`, options.baseUrl),
     {
       method: 'POST',
       headers: {

--- a/src/render/GameScene.ts
+++ b/src/render/GameScene.ts
@@ -633,9 +633,15 @@ export class GameScene extends Phaser.Scene {
     if (!this.netSession?.apiBaseUrl || !this.netSession.roomId) {
       return;
     }
+    const playerId =
+      this.netClient?.playerId ?? useNetStore.getState().playerId;
+    if (!playerId) {
+      return;
+    }
     try {
       await leaveRoom(this.netSession.roomId, {
         baseUrl: this.netSession.apiBaseUrl,
+        playerId,
       });
     } catch (error) {
       if (NET_CFG.debug) {


### PR DESCRIPTION
## Summary
- document the POST /v1/rooms/{roomId}/leave request body to include playerId and optional reason
- explain that the server validates playerId against the wsToken and returns 422 if missing or mismatched
- send the authenticated playerId in client leave room requests so the API call succeeds

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d55ec37aa0832db98985c114d65398