### PR TITLE
Fix remote player label visibility during matches

### DIFF
--- a/src/render/GameScene.ts
+++ b/src/render/GameScene.ts
@@ -548,6 +548,9 @@ export class GameScene extends Phaser.Scene {
       state.sprite.setPosition(Math.round(state.x), Math.round(-state.y));
       state.sprite.setVisible(state.alive);
       state.sprite.setAlpha(state.alive ? 0.85 : 0.3);
+      state.label.setPosition(Math.round(state.x), Math.round(-state.y));
+      state.label.setVisible(state.alive);
+      state.label.setAlpha(state.alive ? 0.85 : 0.3);
     }
 
     this.applyNetEvents(snapshot.events);


### PR DESCRIPTION
## Summary
- update snapshot handling so remote player nameplates follow their avatars and honor alive state

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d563a46bd4832db9627e64871ac1d2