### PR TITLE
Align client with updated start roster protocol

### DIFF
--- a/src/net/Protocol.ts
+++ b/src/net/Protocol.ts
@@ -140,7 +140,7 @@ export interface S2CWelcome {
   seed: string;
   role: PlayerRole;
   roomState: NetRoomState;
-  lobby: LobbySnapshot;
+  lobby?: LobbySnapshot;
   cfg: NetConfig;
   featureFlags?: Record<string, boolean>;
 }
@@ -184,6 +184,7 @@ export interface S2CStart {
   serverTick: number;
   serverTimeMs: number;
   tps: number;
+  players: LobbyPlayer[];
 }
 
 export interface S2CRoleChanged {


### PR DESCRIPTION
## Summary
- allow optional lobby snapshots in `welcome` frames and require the roster in `start`
- keep the client lobby store synchronized with the roster broadcast in `start`
- extend guard tests to cover the new protocol edge cases

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d56b5d5018832dbd69e167eecd6e47